### PR TITLE
Support azure deployment names

### DIFF
--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -49,8 +49,9 @@ const handler = async (req: Request): Promise<Response> => {
 
     const models: OpenAIModel[] = json.data
       .map((model: any) => {
+        const model_name = OPENAI_API_TYPE === 'azure'? model.model: model.id
         for (const [key, value] of Object.entries(OpenAIModelID)) {
-          if (value === model.id) {
+          if (value === model_name) {
             return {
               id: model.id,
               name: OpenAIModels[value].name,

--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -49,7 +49,7 @@ const handler = async (req: Request): Promise<Response> => {
 
     const models: OpenAIModel[] = json.data
       .map((model: any) => {
-        const model_name = OPENAI_API_TYPE === 'azure'? model.model: model.id
+        const model_name = OPENAI_API_TYPE === 'azure' ? model.model : model.id
         for (const [key, value] of Object.entries(OpenAIModelID)) {
           if (value === model_name) {
             return {


### PR DESCRIPTION
when you do an azure deployment, you can give it any name you want.

I did a quick change to support custom deployment names, but not changing the user interface.

The result is that two deployments of the same model are not supported, just the first one, as returned by azure API.