### PR TITLE
Support for custom deplyment names in Azure

### DIFF
--- a/pages/api/models.ts
+++ b/pages/api/models.ts
@@ -5,61 +5,66 @@ export const config = {
   runtime: 'edge',
 };
 
+const findModels = async (key : string | undefined): Promise<OpenAIModel[]> => {
+
+  let url = `${OPENAI_API_HOST}/v1/models`;
+  if (OPENAI_API_TYPE === 'azure') {
+    url = `${OPENAI_API_HOST}/openai/deployments?api-version=${OPENAI_API_VERSION}`;
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(OPENAI_API_TYPE === 'openai' && {
+        Authorization: `Bearer ${key ? key : process.env.OPENAI_API_KEY}`
+      }),
+      ...(OPENAI_API_TYPE === 'azure' && {
+        'api-key': `${key ? key : process.env.OPENAI_API_KEY}`
+      }),
+      ...((OPENAI_API_TYPE === 'openai' && OPENAI_ORGANIZATION) && {
+        'OpenAI-Organization': OPENAI_ORGANIZATION,
+      }),
+    },
+  });
+
+  if (response.status === 401) {
+    throw new Error(await response.text()) ;
+  } else if (response.status !== 200) {
+    console.error(
+      `OpenAI API returned an error ${
+        response.status
+      }: ${await response.text()}`,
+    );
+    throw new Error('OpenAI API returned an error');
+  }
+
+  const json = await response.json();
+
+  const models: OpenAIModel[] = json.data
+    .map((model: any) => {
+      const modelId = OPENAI_API_TYPE === 'azure' ? model.model : model.id
+      for (const [key, value] of Object.entries(OpenAIModelID)) {
+        if (value === modelId) {
+          return {
+            id: modelId,
+            name: OpenAIModels[modelId as OpenAIModelID].name,
+            alias: model.id
+          };
+        }
+      }
+    })
+    .filter(Boolean);
+
+    return models ;
+}
+
 const handler = async (req: Request): Promise<Response> => {
   try {
     const { key } = (await req.json()) as {
       key: string;
     };
 
-    let url = `${OPENAI_API_HOST}/v1/models`;
-    if (OPENAI_API_TYPE === 'azure') {
-      url = `${OPENAI_API_HOST}/openai/deployments?api-version=${OPENAI_API_VERSION}`;
-    }
-
-    const response = await fetch(url, {
-      headers: {
-        'Content-Type': 'application/json',
-        ...(OPENAI_API_TYPE === 'openai' && {
-          Authorization: `Bearer ${key ? key : process.env.OPENAI_API_KEY}`
-        }),
-        ...(OPENAI_API_TYPE === 'azure' && {
-          'api-key': `${key ? key : process.env.OPENAI_API_KEY}`
-        }),
-        ...((OPENAI_API_TYPE === 'openai' && OPENAI_ORGANIZATION) && {
-          'OpenAI-Organization': OPENAI_ORGANIZATION,
-        }),
-      },
-    });
-
-    if (response.status === 401) {
-      return new Response(response.body, {
-        status: 500,
-        headers: response.headers,
-      });
-    } else if (response.status !== 200) {
-      console.error(
-        `OpenAI API returned an error ${
-          response.status
-        }: ${await response.text()}`,
-      );
-      throw new Error('OpenAI API returned an error');
-    }
-
-    const json = await response.json();
-
-    const models: OpenAIModel[] = json.data
-      .map((model: any) => {
-        const model_name = OPENAI_API_TYPE === 'azure' ? model.model : model.id
-        for (const [key, value] of Object.entries(OpenAIModelID)) {
-          if (value === model_name) {
-            return {
-              id: model.id,
-              name: OpenAIModels[value].name,
-            };
-          }
-        }
-      })
-      .filter(Boolean);
+    const models = findModels(key) ;
 
     return new Response(JSON.stringify(models), { status: 200 });
   } catch (error) {
@@ -69,3 +74,9 @@ const handler = async (req: Request): Promise<Response> => {
 };
 
 export default handler;
+
+export const findModelById = async (modelId: string) => {
+  const models: OpenAIModel[] = await findModels(undefined) ;
+
+  return models.find((model: OpenAIModel) => model.id == modelId) ;
+}

--- a/types/openai.ts
+++ b/types/openai.ts
@@ -5,6 +5,7 @@ export interface OpenAIModel {
   name: string;
   maxLength: number; // maximum length of a message
   tokenLimit: number;
+  alias?: string ; // optional alias, used by Azure backend
 }
 
 export enum OpenAIModelID {

--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -6,6 +6,7 @@ import {
   ReconnectInterval,
 } from 'eventsource-parser';
 import { OPENAI_API_HOST, OPENAI_API_TYPE, OPENAI_API_VERSION, OPENAI_ORGANIZATION } from '../app/const';
+import { findModelById } from '../../pages/api/models' ;
 
 export class OpenAIError extends Error {
   type: string;
@@ -29,7 +30,9 @@ export const OpenAIStream = async (
 ) => {
   let url = `${OPENAI_API_HOST}/v1/chat/completions`;
   if (OPENAI_API_TYPE === 'azure') {
-    url = `${OPENAI_API_HOST}/openai/deployments/${model.id}/chat/completions?api-version=${OPENAI_API_VERSION}`;
+    // Find out under which model name `model.id` is deployied
+    const azureModel = await findModelById(model.id) ;
+    url = `${OPENAI_API_HOST}/openai/deployments/${azureModel?.alias}/chat/completions?api-version=${OPENAI_API_VERSION}`;
   }
   const res = await fetch(url, {
     headers: {


### PR DESCRIPTION
Hi,

This is an implementation that supports custom model names in Azure. From the giving implementation, the custom name must be `gpt-35-turbo`.

*What my code does?*
Basically, it finds the deployment name that matches a supported model-id (as specified in openai.ts file).

*What could be better?*
It adds a new lookup to the endpoint `/openai/deployments` for every chat call. I think that this call could be cached, but there may be a better solution.
Another catch is that I don't have an OpenAI Key to test the code... so I cannot ensure that it is working well with it.

Regards,
Bruno